### PR TITLE
Fix closure conversion expressions

### DIFF
--- a/staged-builder/src/lib.rs
+++ b/staged-builder/src/lib.rs
@@ -43,6 +43,11 @@ pub mod __private {
     pub use core::default::Default;
     pub use core::iter::{Extend, FromIterator, IntoIterator, Iterator};
     pub use core::result::Result;
+
+    #[inline]
+    pub fn call_hack<T, R>(f: impl FnOnce(T) -> R, v: T) -> R {
+        f(v)
+    }
 }
 
 /// A trait for types which validate their state before construction finishes.

--- a/staged-builder/tests/test.rs
+++ b/staged-builder/tests/test.rs
@@ -169,3 +169,22 @@ fn custom_mod() {
     CustomMod::builder()._foo(1).build();
     my_custom_mod::Builder::default()._foo(1).build();
 }
+
+#[derive(PartialEq, Debug)]
+#[staged_builder]
+struct ClosureConvert {
+    #[builder(custom(type = impl Display, convert = |s| s.to_string()))]
+    single: String,
+    #[builder(list(item(custom(type = impl Display, convert = |s| s.to_string()))))]
+    list: Vec<String>,
+}
+
+#[test]
+fn closure_convert() {
+    let actual = ClosureConvert::builder().single(true).push_list(15).build();
+    let expected = ClosureConvert {
+        single: "true".to_string(),
+        list: vec!["15".to_string()],
+    };
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
There's something weird going on with the compiler's type inference around directly-invoked closure expressions so we have to add a little hack to make these work. This does make the custom conversion support significantly more convenient though!

Closes #10